### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.1"
 edition = "2021"
 license = "Unlicense"
 readme = "README.md"
-homepage = "https://github.com/Nydragon/rofi-obsidian"
+repository = "https://github.com/Nydragon/rofi-obsidian"
 
 [profile.release]
 opt-level = 'z'   # Optimize for size


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.