### PR TITLE
19 display icon next to vault entry

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -19,7 +19,7 @@ body = """
 {% else %}\
     ## [unreleased]
 {% endif %}\
-{% for group, commits in commits | group_by(attribute="group") %}
+{% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\

--- a/src/args.rs
+++ b/src/args.rs
@@ -36,4 +36,6 @@ pub struct Args {
     pub selection: Option<String>,
     #[clap(short, long, help = "The style of the vault name")]
     pub name: Option<DisplayName>,
+    #[clap(short, long, help = "The icon to display for each entry")]
+    pub icon: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub enum DisplayName {
 pub struct Config {
     pub display_name: DisplayName,
     pub source: Source,
+    #[serde(default = "default_icon")]
+    pub icon: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -48,6 +50,10 @@ impl Config {
         write(path.clone(), toml::to_string(self)?)?;
         Ok(path)
     }
+}
+
+fn default_icon() -> String {
+    "obsidian".to_string()
 }
 
 impl Default for Source {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ fn get_known_vaults(conf: &Config) -> Vec<String> {
 fn rofi_main(state: u8, conf: Config, args: Args) -> Result<()> {
     let rofi_info: String = env::var("ROFI_INFO").unwrap_or_default();
     let name_style = args.name.unwrap_or(conf.display_name.clone());
+    let icon = args.icon.unwrap_or(conf.icon.clone());
 
     match state {
         // Prompting which vault to open
@@ -107,7 +108,7 @@ fn rofi_main(state: u8, conf: Config, args: Args) -> Result<()> {
                     DisplayName::Unique => unique_names.get(i).unwrap(),
                 };
 
-                println!("{name}\0info\x1f{vault}");
+                println!("{name}\0icon\x1f{icon}\x1finfo\x1f{vault}");
             });
         }
         // Opening the selected vault


### PR DESCRIPTION
The icon defaults to "obsidian" but can be configured either through a
flag or in the config file, the former taking precedence.

Closes #19 